### PR TITLE
Fix setting env variable with gcloud credentials within `runuser`

### DIFF
--- a/k8s-sftp-gcs/templates/configmap.yaml
+++ b/k8s-sftp-gcs/templates/configmap.yaml
@@ -7,11 +7,10 @@ data:
     #!/bin/bash
     {{ range $item, $user := .Values.users -}}
     runuser -l {{ $user.user }} -c \
-      export GOOGLE_APPLICATION_CREDENTIALS=/credentials/gcloud-key.json
       {{- if $user.onlyDir }}
-      'gcsfuse --only-dir {{ $user.onlyDir }} {{ $user.bucket }} /home/{{ $user.user }}/ftp'
+      'export GOOGLE_APPLICATION_CREDENTIALS=/credentials/gcloud-key.json; gcsfuse --only-dir {{ $user.onlyDir }} {{ $user.bucket }} /home/{{ $user.user }}/ftp'
       {{ else }}
-      'gcsfuse {{ $user.bucket }} /home/{{ $user.user }}/ftp'
+      'export GOOGLE_APPLICATION_CREDENTIALS=/credentials/gcloud-key.json; gcsfuse {{ $user.bucket }} /home/{{ $user.user }}/ftp'
       {{- end }}
     {{ end }}
 ---


### PR DESCRIPTION
See: https://github.com/danuk/k8s-sftp-gcs/issues/1